### PR TITLE
Update elasticsearch image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Adapted from:
   #   https://www.elastic.co/guide/en/apm/get-started/current/quick-start-overview.html
   elastic:
-    image: elasticsearch:7.14.0
+    image: elasticsearch:7.17.6
     ports:
       - 9200:9200
       - 9300:9300


### PR DESCRIPTION
Version 7.14.0 contains known vulnerabilities of Log4Shell.

References:
CVE-2021-44228 / CVE-2021-45046
https://www.docker.com/blog/apache-log4j-2-cve-2021-44228/